### PR TITLE
fixed method to register custom user types

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -41,10 +41,11 @@ type Env struct {
 
 // HTTPHandlerConfig is a config to setup bridge http handler.
 type HTTPHandlerConfig struct {
-	Logger          logr.Logger
-	PublicKeyGetter auth.PublicKeyGetter
-	TenantID        string
-	Middlewares     []bridgehttp.Middleware
+	Logger             logr.Logger
+	PublicKeyGetter    auth.PublicKeyGetter
+	RegisterUserObject auth.TenantIDGetter
+	TenantID           string
+	Middlewares        []bridgehttp.Middleware
 }
 
 // NewHTTPHandler is a handler for handling any requests.
@@ -60,9 +61,10 @@ func NewHTTPHandler(c *HTTPHandlerConfig) http.Handler {
 	middlewares := append(c.Middlewares,
 		ctxtime.Middleware(),
 		auth.Middleware(&auth.MiddlewareConfig{
-			TenantID:        c.TenantID,
-			Logger:          c.Logger.WithName("auth"),
-			PublicKeyGetter: c.PublicKeyGetter,
+			TenantID:           c.TenantID,
+			Logger:             c.Logger.WithName("auth"),
+			PublicKeyGetter:    c.PublicKeyGetter,
+			RegisterUserObject: c.RegisterUserObject,
 		}),
 	)
 	mux.Handle(ProxyPath, bridgehttp.UseMiddlewares(

--- a/cmd/bridge/container.go
+++ b/cmd/bridge/container.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/basemachina/bridge"
+	"github.com/basemachina/bridge/internal/auth"
 	"github.com/go-logr/logr"
 )
 
@@ -27,9 +28,10 @@ func BridgeContainerProvider() (*Container, func(), error) {
 		return nil, nil, err
 	}
 	httpHandlerConfig := &bridge.HTTPHandlerConfig{
-		Logger:          logger,
-		PublicKeyGetter: fetchWorker,
-		TenantID:        env.TenantID,
+		Logger:             logger,
+		PublicKeyGetter:    fetchWorker,
+		TenantID:           env.TenantID,
+		RegisterUserObject: auth.User{},
 	}
 	handler := bridge.NewHTTPHandler(httpHandlerConfig)
 	server, cleanup3, err := NewHTTPServer(env, handler)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -106,6 +106,7 @@ func TestMiddleware(t *testing.T) {
 				PublicKeyGetter: &StaticPublicKeyGetter{
 					PublicKey: ret.PublicKeySet,
 				},
+				RegisterUserObject: User{},
 			})
 			middleware(h).ServeHTTP(rec, tc.req)
 			if tc.wantStatus != rec.Code {


### PR DESCRIPTION
Changed the way to register user type
`RegisterCustomField` calls are now optional.