### PR TITLE
added actions to build container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           context: .
-          push: startsWith(github.ref, 'refs/tags/v')
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Build bridge's Container image
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*'
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: ghcr.io/basemachina/bridge
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: basemachina
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: startsWith(github.ref, 'refs/tags/v')
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - name: Move cache
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Build bridge's Container image
 on:
   push:
-    branches-ignore:
-      - '**'
     tags:
       - 'v*'
+  pull_request:
 
 jobs:
   build-container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.18-alpine3.15 AS builder
+ARG VERSION
+ENV CGO_ENABLED=0
+WORKDIR /go/src/github.com/basemachina/bridge
+COPY . .
+RUN go build -mod=readonly -o bridge -trimpath -ldflags "-w -s -X main.version=$VERSION -X main.serviceName=bridge" ./cmd/bridge
+
+# runtime image
+FROM alpine:3.15
+RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
+COPY --from=builder --chown=nonroot:nonroot /go/src/github.com/basemachina/bridge /bridge
+
+# hadolint ignore=DL3018
+RUN apk update && apk add --no-cache ca-certificates \
+    'libretls>3.3.4-r2' # CVE-2022-0778
+USER nonroot
+EXPOSE 8080
+CMD ["/bridge"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/basemachina/bridge
 COPY . .
-RUN go build -mod=readonly -o bridge -trimpath -ldflags "-w -s -X main.version=$VERSION -X main.serviceName=bridge" ./cmd/bridge
+RUN go build -mod=readonly -o bridge -buildvcs=false -trimpath -ldflags "-w -s -X main.version=$VERSION -X main.serviceName=bridge" ./cmd/bridge
 
 # runtime image
 FROM alpine:3.15

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -19,9 +19,6 @@ import (
 var (
 	serviceName string
 	version     string
-	// TODO(codehex): どこかしらから取得できるようにしたい
-	// basemachina api の ua も含めるなら、context から取得したほうが良さそう
-	defaultUA = "basemachina-bridge/" + version
 )
 
 func main() {


### PR DESCRIPTION
- added actions to build container image for bridge
  - A flag `-buildvcs=false` is now required. see: https://github.com/golang/go/issues/51723
- this PR makes a workflow to push the bridge container image to ghcr.io