### PR TITLE
fixed bridge auth config accepts tenant ID as empty

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -97,7 +97,7 @@ func Middleware(c *MiddlewareConfig) bridgehttp.Middleware {
 				return
 			}
 
-			if tenantID != c.TenantID {
+			if c.TenantID != "" && tenantID != c.TenantID {
 				c.Logger.Info("mismatch tenant ID", tenantID, c.TenantID)
 				w.WriteHeader(http.StatusUnauthorized)
 				return

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -50,6 +50,19 @@ func TestMiddleware(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			name: "valid tenant ID config is empty",
+			req: func() *http.Request {
+				req := httptest.NewRequest("GET", "/", nil)
+				req.Header.Add(headerKey, "bearer "+string(accessToken))
+				ctx := req.Context()
+				now := tm.Add(time.Second) // adding for "nbf"
+				ctx = ctxtime.WithTime(ctx, now)
+				return req.WithContext(ctx)
+			}(),
+			tenantID:   "",
+			wantStatus: http.StatusOK,
+		},
+		{
 			name: "invalid mismatch tenant ID",
 			req: func() *http.Request {
 				req := httptest.NewRequest("GET", "/", nil)


### PR DESCRIPTION
This is helpful when you want to pass through requests that are not limited to a particular tenant.