### PR TITLE
fixed build-container actions to push gcr.io

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,8 +39,10 @@ jobs:
         uses: 'google-github-actions/auth@v0'
         id: auth
         with:
+          token_format: access_token
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          access_token_lifetime: 300s
       - uses: docker/login-action@v1
         with:
           registry: gcr.io

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: docker/metadata-action@v3
         id: meta
         with:
-          images: ghcr.io/basemachina/bridge
+          images: |
+            ghcr.io/basemachina/bridge
+            gcr.io/basemachina/bridge
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -30,6 +32,17 @@ jobs:
           registry: ghcr.io
           username: basemachina
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Authenticate to Google Cloud
+        uses: 'google-github-actions/auth@v0'
+        id: auth
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      - uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
       - uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build-container:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We setup build-container actions to push gcr.io/basemachina/bridge
GCP Serverless platform is required to deploy the container image from gcr.io.